### PR TITLE
🐛 エンコード前にファイルの存在チェック処理を追加

### DIFF
--- a/SynapseMediaEncoder/MediaEncoder.cs
+++ b/SynapseMediaEncoder/MediaEncoder.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows;
 using FFmpeg.NET;
 using FFmpeg.NET.Enums;
 using Reactive.Bindings;
@@ -84,6 +85,13 @@ public class MediaEncoder
         };
         
         CancellationToken fake = new CancellationToken();
+
+        // ファイルが存在しない場合falseを返す
+        if (!File.Exists(encodeInfo.inputPath.Value))
+        {
+            MessageBox.Show($"ファイルが存在しません\n{encodeInfo.inputPath.Value}", "Warning", MessageBoxButton.OK, MessageBoxImage.Warning);
+            return false;
+        }
         await ffmpeg.ConvertAsync(inputFile, outputFile, conversionOptions,fake);
         
         return true;

--- a/SynapseMediaEncoder/MediaEncoder.cs
+++ b/SynapseMediaEncoder/MediaEncoder.cs
@@ -1,14 +1,12 @@
+using FFmpeg.NET;
+using FFmpeg.NET.Enums;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
-using FFmpeg.NET;
-using FFmpeg.NET.Enums;
-using Reactive.Bindings;
 
 namespace SynapseMediaEncoder;
 


### PR DESCRIPTION
## 概要

- ffmpegでのエンコードを開始する前に `File.Exists` による存在チェックを追加
  - 存在しない場合 `false` を返却しつつ `Messagebox` によるアラートの表示を行う

closes #1

## プレビュー

![image](https://github.com/SainaKey/SynapseMediaEncoder/assets/19209846/2fe1493d-4739-4976-ab31-3c88e1ccd012)
